### PR TITLE
[i18n/ru] Removing an extra letter in a pinterest string

### DIFF
--- a/i18n/ru.yaml
+++ b/i18n/ru.yaml
@@ -60,7 +60,7 @@ sharing:
   email: "Отправить по электронной почте"
   facebook: "Поделиться через Facebook"
   linkedin: "Поделиться через LinkedIn"
-  pinterest: "PДобавить в Pinterest"
+  pinterest: "Добавить в Pinterest"
   reddit: "Отправить в Reddit"
   twitter: "Твитнуть в Twitter"
 


### PR DESCRIPTION
I found an error in spelling and corrected it. [Check](https://advego.com/text/):
![2023-11-16_13-41](https://github.com/OldTyT/blowfish/assets/42464565/234723cd-d937-44f0-873b-cd0f4a9abdde)
